### PR TITLE
feat: add mcp() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Python: uv/pyenv version management, virtualenv helpers,
+VSCode extensions, and MCP server (`mcp-pypi` via `uv tool install`) for
+AI-driven PyPI package discovery and dependency analysis.
 
 ## Contributing
 
@@ -40,8 +42,10 @@ TODO: Add a short summary of this module.
 - `p6df::modules::python::external::yum()`
 - `p6df::modules::python::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module
+    - dir
+- `p6df::modules::python::mcp()`
+- `p6df::modules::python::pyproject::toml()`
 - `p6df::modules::python::vscodes()`
 - `p6df::modules::python::vscodes::config()`
 - `str str = p6df::modules::python::prompt::env()`

--- a/init.zsh
+++ b/init.zsh
@@ -233,3 +233,17 @@ p6df::modules::python::prompt::lang() {
 
   p6_return_str "$str"
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::python::mcp()
+#
+#>
+######################################################################
+p6df::modules::python::mcp() {
+
+  uv tool install mcp-pypi
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary

- Add `mcp()` hook: installs `mcp-pypi` via `uv tool install` for AI-driven PyPI package discovery and dependency analysis via MCP (`uvx mcp-pypi serve`)

## Test plan

- [ ] `p6df mcp` runs `uv tool install mcp-pypi`
- [ ] `uvx mcp-pypi serve` works after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)