### PR TITLE
feat: add python-engineer skill and fix PYTHONPATH prompt

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,11 +16,11 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run claude review
-        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
         continue-on-error: true
         uses: p6m7g8-actions/claude@main
         with:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,9 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 permissions:
@@ -13,11 +16,12 @@ jobs:
   codex-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping review in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping review in queue context"
       - name: Run codex review
-        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        continue-on-error: true
         uses: p6m7g8-actions/codex@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,9 @@ on:
       - reopened
       - ready_for_review
       - edited
+  push:
+    branches:
+      - gh-readonly-queue/**
   merge_group: {}
 
 jobs:
@@ -18,11 +21,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Skip on merge queue
-        if: github.event_name == 'merge_group'
-        run: echo "Skipping lint in merge queue context"
+      - name: Skip on queue refs
+        if: github.event_name == 'merge_group' || github.event_name == 'push'
+        run: echo "Skipping lint in queue context"
       - name: Lint PR title
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request_target'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/init.zsh
+++ b/init.zsh
@@ -12,6 +12,7 @@ p6df::modules::python::deps() {
     matthiasha/zsh-uv-env
     astral-sh/uv
     ohmyzsh/ohmyzsh:plugins/uv
+    rohitg00/awesome-claude-code-toolkit:agents/language-experts/python-engineer.md
   )
 }
 
@@ -207,7 +208,10 @@ p6df::modules::python::prompt::env() {
     str="uv:\t\t  ${VIRTUAL_ENV_PROMPT:-none}$P6_NL"
   fi
   if p6_string_blank_NOT "$PYTHONPATH"; then
-    str="${str}pythonpath:\t  $PYTHONPATH$P6_NL"
+    case $PYTHONPATH in
+      $P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib) str="" ;;
+      *) str="${str}pythonpath:\t  $PYTHONPATH$P6_NL" ;;
+    esac
   fi
 
   p6_return_str "$str"

--- a/init.zsh
+++ b/init.zsh
@@ -209,7 +209,7 @@ p6df::modules::python::prompt::env() {
   fi
   if p6_string_blank_NOT "$PYTHONPATH"; then
     case $PYTHONPATH in
-      "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib") str="" ;;
+      "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib") : ;;
       *) str="${str}pythonpath:\t  $PYTHONPATH$P6_NL" ;;
     esac
   fi

--- a/init.zsh
+++ b/init.zsh
@@ -209,7 +209,7 @@ p6df::modules::python::prompt::env() {
   fi
   if p6_string_blank_NOT "$PYTHONPATH"; then
     case $PYTHONPATH in
-      $P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib) str="" ;;
+      "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib") str="" ;;
       *) str="${str}pythonpath:\t  $PYTHONPATH$P6_NL" ;;
     esac
   fi


### PR DESCRIPTION
## Summary
- Adds `rohitg00/awesome-claude-code-toolkit:agents/language-experts/python-engineer.md` to `ModuleDeps`
- Fixes `p6df::modules::python::prompt::env()` to suppress `PYTHONPATH` display when it matches the default p6python lib path, reducing prompt noise

## Test plan
- [ ] Verify `p6df::modules::python::deps()` includes the new python-engineer skill
- [ ] Verify prompt suppresses `pythonpath:` line when `PYTHONPATH` equals `$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6python/lib`
- [ ] Verify prompt shows `pythonpath:` line when `PYTHONPATH` is set to a custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)