### PR TITLE
feat(python): add p6_python_uv_tool_install

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -266,7 +266,7 @@ p6_python_uv_tool_install() {
   local pkg="$1"
 
   (
-    cd ~
+    cd ~ || return
     uv tool uninstall "$pkg"
     uv tool install "$pkg"
     uv tool list

--- a/init.zsh
+++ b/init.zsh
@@ -251,3 +251,24 @@ p6df::modules::python::mcp() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6_python_uv_tool_install(pkg)
+#
+#  Args:
+#	pkg - package name or VCS reference
+#
+#>
+######################################################################
+p6_python_uv_tool_install() {
+  local pkg="$1"
+
+  (
+    cd ~
+    uv tool uninstall "$pkg"
+    uv tool install "$pkg"
+    uv tool list
+  )
+}

--- a/init.zsh
+++ b/init.zsh
@@ -271,4 +271,6 @@ p6_python_uv_tool_install() {
     uv tool install "$pkg"
     uv tool list
   )
+
+  p6_return_void
 }


### PR DESCRIPTION
## Summary

- Adds `p6_python_uv_tool_install(pkg)` — uninstalls, installs, and lists uv tools; runs from `~` so uv operates in global context

## Why

Mirrors `p6_js_npm_global_install` pattern from p6df-js. p6df-zoom's `mcp()` hook needs to install `zoom-mcp` via uv tool; using this helper keeps the pattern consistent across language modules.

## Test plan

- [ ] `p6_python_uv_tool_install ruff` installs ruff globally
- [ ] `uv tool list` shows the installed tool
- [ ] Running from a project directory with a local `pyproject.toml` does not affect the global install

🤖 Generated with [Claude Code](https://claude.com/claude-code)