### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -154,11 +154,11 @@ p6df::modules::python::external::yum() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::python::external::brew()
+# Function: p6df::modules::python::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::python::external::brew() {
+p6df::modules::python::external::brews() {
 
   p6df::core::homebrew::cli::brew::install uv
   p6df::core::homebrew::cli::brew::install watchman


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly