### PR TITLE
chore(python): add home::symlinks to manage ~/.pip

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -154,6 +154,20 @@ p6df::modules::python::external::yum() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::python::home::symlinks()
+#
+#>
+######################################################################
+p6df::modules::python::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-python/share/.pip" "$HOME/.pip"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::python::external::brews()
 #
 #>


### PR DESCRIPTION
## What
Add `home::symlinks()` function to manage `~/.pip` symlink via the framework.

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The module had no such function, meaning `~/.pip` was only symlinked from a prior manual action and would not be recreated by `p6df home symlinks`.

## Test plan
- `p6df home symlinks` now recreates `~/.pip -> .../p6df-python/share/.pip`

## Dependencies
None