### PR TITLE
fix(prompt): fix pythonpath label and remove extra blank line

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -198,13 +198,12 @@ p6df::modules::python::path::init() {
 p6df::modules::python::prompt::system() {
 
   local str=""
-
   local ver=$(uv python pin 2>/dev/null)
   if p6_string_blank_NOT "$ver"; then
     str="$(p6_string_space_pad "uv:" 16)${VIRTUAL_ENV_PROMPT:-none}$P6_NL"
   fi
   if p6_string_blank_NOT "$PYTHONPATH"; then
-    str="${str}$(p6_string_space_pad "pythonpath:" 16)$PYTHONPATH$P6_NL"
+    str="${str}$(p6_string_space_pad "python:" 16)$PYTHONPATH$P6_NL"
   fi
 
   p6_return_str "$str"


### PR DESCRIPTION
## What
Two small fixes in `p6df::modules::python::prompt::system()`:
1. Change the prompt label from `"pythonpath:"` to `"python:"` for consistency
2. Remove extraneous blank line after `local str=""`

## Why
The label `"pythonpath:"` was inconsistent with the shorter label style used elsewhere. The blank line was unnecessary whitespace.

## Test plan
- Verified diff looks correct
- Prompt output will now show `python:` instead of `pythonpath:` for the PYTHONPATH display

## Dependencies
None