### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::python::deps()
-#
-#>
-######################################################################
 p6df::modules::python::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6python
@@ -17,11 +11,43 @@ p6df::modules::python::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::python::vscodes()
-#
-#>
+p6df::modules::python::path::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_path_if "$HOME/.local/bin"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::python::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-python/share/.pip" "$HOME/.pip"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::python::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install uv
+  p6df::core::homebrew::cli::brew::install watchman
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::python::mcp() {
+
+  p6_python_uv_tool_install "mcp-pypi"
+
+  p6df::modules::anthropic::mcp::server::add "python" "uvx" "mcp-pypi"
+  p6df::modules::openai::mcp::server::add "python" "uvx" "mcp-pypi"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::python::vscodes() {
 
@@ -41,12 +67,6 @@ p6df::modules::python::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::python::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::python::vscodes::config() {
 
@@ -70,6 +90,24 @@ EOF
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::python::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::python::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::python::vscodes::config()
+#
+#>
 ######################################################################
 #<
 #
@@ -145,28 +183,11 @@ EOF
 #  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::python::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-python/share/.pip" "$HOME/.pip"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::python::external::brews()
 #
 #>
-######################################################################
-p6df::modules::python::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install uv
-  p6df::core::homebrew::cli::brew::install watchman
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -174,16 +195,6 @@ p6df::modules::python::external::brews() {
 #
 #  Environment:	 HOME
 #>
-######################################################################
-p6df::modules::python::path::init() {
-
-  local _module="$1"
-  local _dir="$2"
-  p6_path_if "$HOME/.local/bin"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -236,17 +247,6 @@ p6df::modules::python::prompt::lang() {
 # Function: p6df::modules::python::mcp()
 #
 #>
-######################################################################
-p6df::modules::python::mcp() {
-
-  p6_python_uv_tool_install "mcp-pypi"
-
-  p6df::modules::anthropic::mcp::server::add "python" "uvx" "mcp-pypi"
-  p6df::modules::openai::mcp::server::add "python" "uvx" "mcp-pypi"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::python::deps()
+#
+#>
+######################################################################
 p6df::modules::python::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6python
@@ -11,6 +17,13 @@ p6df::modules::python::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::python::path::init()
+#
+#  Environment:	 HOME
+#>
+######################################################################
 p6df::modules::python::path::init() {
 
   local _module="$1"
@@ -21,6 +34,13 @@ p6df::modules::python::path::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::python::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::python::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-python/share/.pip" "$HOME/.pip"
@@ -28,6 +48,12 @@ p6df::modules::python::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::python::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::python::external::brews() {
 
@@ -37,6 +63,12 @@ p6df::modules::python::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::python::mcp()
+#
+#>
 ######################################################################
 p6df::modules::python::mcp() {
 
@@ -48,6 +80,12 @@ p6df::modules::python::mcp() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::python::vscodes()
+#
+#>
 ######################################################################
 p6df::modules::python::vscodes() {
 
@@ -67,6 +105,12 @@ p6df::modules::python::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::python::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::python::vscodes::config() {
 
@@ -90,24 +134,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::python::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::python::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::python::vscodes::config()
-#
-#>
 ######################################################################
 #<
 #
@@ -178,26 +204,6 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::python::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::python::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::python::path::init()
-#
-#  Environment:	 HOME
-#>
-######################################################################
-#<
-#
 # Function: str str = p6df::modules::python::prompt::runtime()
 #
 #  Returns:
@@ -241,12 +247,6 @@ p6df::modules::python::prompt::lang() {
   p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::python::mcp()
-#
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None