### PR TITLE
feat(python): add pyproject and uv lib helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 ## Summary
 
-p6df module for Python: pyenv, pip, and virtual environment tooling,
-plus MCP server (`mcp-pypi` via uvx) for AI-driven PyPI package intelligence.
+TODO: Add a short summary of this module.
 
 ## Contributing
 
@@ -37,18 +36,29 @@ plus MCP server (`mcp-pypi` via uvx) for AI-driven PyPI package intelligence.
 ##### p6df-python/init.zsh
 
 - `p6df::modules::python::deps()`
-- `p6df::modules::python::external::brew()`
-- `p6df::modules::python::external::yum()`
-- `p6df::modules::python::init(_module, dir)`
+- `p6df::modules::python::external::brews()`
+- `p6df::modules::python::home::symlinks()`
+- `p6df::modules::python::mcp()`
+- `p6df::modules::python::path::init(_module, _dir)`
   - Args:
     - _module
-    - dir
-- `p6df::modules::python::mcp()`
-- `p6df::modules::python::pyproject::toml()`
+    - _dir
 - `p6df::modules::python::vscodes()`
 - `p6df::modules::python::vscodes::config()`
-- `str str = p6df::modules::python::prompt::env()`
 - `str str = p6df::modules::python::prompt::lang()`
+- `str str = p6df::modules::python::prompt::system()`
+
+#### p6df-python/lib
+
+##### p6df-python/lib/pyproject.zsh
+
+- `p6df::modules::python::pyproject::toml()`
+
+##### p6df-python/lib/uv.zsh
+
+- `p6_python_uv_tool_install(pkg)`
+  - Args:
+    - pkg
 
 ## Hierarchy
 
@@ -56,10 +66,12 @@ plus MCP server (`mcp-pypi` via uvx) for AI-driven PyPI package intelligence.
 .
 ├── init.zsh
 ├── lib
+│   ├── pyproject.zsh
+│   └── uv.zsh
 ├── README.md
 └── share
 
-3 directories, 2 files
+3 directories, 4 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -19,7 +19,11 @@ p6df::modules::python::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::python::path::init()
+# Function: p6df::modules::python::path::init(_module, _dir)
+#
+#  Args:
+#	_module -
+#	_dir -
 #
 #  Environment:	 HOME
 #>
@@ -137,79 +141,12 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::python::pyproject::toml()
-#
-#>
-######################################################################
-p6df::modules::python::pyproject::toml() {
-
-  cat <<'EOF'
-[project]
-name = "p6-template-uv"
-dynamic = ["version"]
-requires-python = "==3.14.2"
-dependencies = [
-  "docopt",
-]
-
-[dependency-groups]
-dev = [
-  "bandit",
-  "black",
-  "codespell",
-  "coverage",
-  "detect-secrets",
-  "flake8",
-  "isort",
-  "pip-audit",
-  "pre-commit",
-  "pydocstyle",
-  "pylint",
-  "pymarkdownlnt",
-  "pyre-check",
-  "pyre-extensions",
-  "pytest",
-  "pytest-cov",
-  "shellcheck-py",
-  "yamllint",
-]
-
-[tool.setuptools]
-include-package-data = false
-
-[tool.uv]
-index-url = "https://pypi.org/simple"
-
-[tool.black]
-line-length = 120
-
-[tool.isort]
-profile = "black"
-line_length = 120
-
-[tool.flake8]
-max-line-length = 120
-extend-ignore = ["E203"]
-
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-EOF
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::python::prompt::runtime()
+# Function: str str = p6df::modules::python::prompt::system()
 #
 #  Returns:
 #	str - str
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR P6_NL PYTHONPATH VIRTUAL_ENV_PROMPT
+#  Environment:	 P6_NL PYTHONPATH VIRTUAL_ENV_PROMPT
 #>
 ######################################################################
 p6df::modules::python::prompt::system() {
@@ -247,26 +184,3 @@ p6df::modules::python::prompt::lang() {
   p6_return_str "$str"
 }
 
-######################################################################
-#<
-#
-# Function: p6_python_uv_tool_install(pkg)
-#
-#  Args:
-#	pkg -
-#
-#  Environment:	 HOME
-#>
-######################################################################
-p6_python_uv_tool_install() {
-  local pkg="$1"
-
-  (
-    p6_dir_cd "$HOME"
-    uv tool uninstall "$pkg"
-    uv tool install "$pkg"
-    uv tool list
-  )
-
-  p6_return_void
-}

--- a/lib/pyproject.zsh
+++ b/lib/pyproject.zsh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6df::modules::python::pyproject::toml()
+#
+#>
+######################################################################
+p6df::modules::python::pyproject::toml() {
+
+  cat <<'EOF'
+[project]
+name = "p6-template-uv"
+dynamic = ["version"]
+requires-python = "==3.14.2"
+dependencies = [
+  "docopt",
+]
+
+[dependency-groups]
+dev = [
+  "bandit",
+  "black",
+  "codespell",
+  "coverage",
+  "detect-secrets",
+  "flake8",
+  "isort",
+  "pip-audit",
+  "pre-commit",
+  "pydocstyle",
+  "pylint",
+  "pymarkdownlnt",
+  "pyre-check",
+  "pyre-extensions",
+  "pytest",
+  "pytest-cov",
+  "shellcheck-py",
+  "yamllint",
+]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.uv]
+index-url = "https://pypi.org/simple"
+
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.flake8]
+max-line-length = 120
+extend-ignore = ["E203"]
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+EOF
+
+  p6_return_void
+}

--- a/lib/uv.zsh
+++ b/lib/uv.zsh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+######################################################################
+#<
+#
+# Function: p6_python_uv_tool_install(pkg)
+#
+#  Args:
+#	pkg -
+#
+#  Environment:	 HOME
+#>
+######################################################################
+p6_python_uv_tool_install() {
+  local pkg="$1"
+
+  (
+    p6_dir_cd "$HOME"
+    uv tool uninstall "$pkg"
+    uv tool install "$pkg"
+    uv tool list
+  )
+
+  p6_return_void
+}


### PR DESCRIPTION
**What:** Extract pyproject.toml generation and uv tool install helpers into dedicated lib files

**Why:** Improves modularity by separating pyproject and uv functionality into `lib/pyproject.zsh` and `lib/uv.zsh`, and updates function signatures with proper argument documentation

**Test plan:** Shell loads without errors; pyproject and uv functions accessible after sourcing init.zsh

**Dependencies:** none